### PR TITLE
feat: allow custom filename via --name option (#11)

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -11,6 +11,7 @@ program
   .description('A CLI to organize files into categorized folders')
   .option('-d, --dir <directory>', 'Directory to organize', '.')
   .option('-p, --parent <name>', 'Name of the parent folder to store categories (optional)')
+  .option('-n, --name <filename>', 'Custom filename (replaces default date-based name)')
   .action(async (options) => {
     const targetDir = path.resolve(options.dir);
 
@@ -43,16 +44,15 @@ program
           
           await fs.ensureDir(categoryDir);
           
-          const today = new Date().toISOString().split('T')[0]; // yyyy-mm-dd
-          const ext = path.extname(file).toLowerCase();
+          const fileBaseName = options.name ? options.name : new Date().toISOString().split('T')[0]; // Use custom name or today's date
           let counter = 1;
-          let finalFileName = `${today}-${counter}${ext}`;
+          let finalFileName = `${fileBaseName}-${counter}${ext}`;
           let finalDestPath = path.join(categoryDir, finalFileName);
 
           // If file exists, increment running number
           while (await fs.pathExists(finalDestPath)) {
             counter++;
-            finalFileName = `${today}-${counter}${ext}`;
+            finalFileName = `${fileBaseName}-${counter}${ext}`;
             finalDestPath = path.join(categoryDir, finalFileName);
           }
 

--- a/tests/organizer.test.js
+++ b/tests/organizer.test.js
@@ -67,4 +67,13 @@ describe('Smart Organizer CLI', () => {
 
     expect(fs.existsSync(path.join(TEST_DIR, `others/${today}-1.xyz`))).toBe(true);
   });
+
+  test('should use custom filename if --name is provided', async () => {
+    const CUSTOM_NAME = 'my-custom-file';
+    await fs.ensureFile(path.join(TEST_DIR, 'photo.jpg'));
+
+    runCLI(`-d ${TEST_DIR} --name ${CUSTOM_NAME}`);
+
+    expect(fs.existsSync(path.join(TEST_DIR, `images/${CUSTOM_NAME}-1.jpg`))).toBe(true);
+  });
 });


### PR DESCRIPTION
Added a new CLI option --name (-n) to allow users to specify a custom base filename for organized files. If provided, this name will be used instead of the default yyyy-mm-dd format. Added test case for verification.